### PR TITLE
ed25519/x25519: simplify key implementation, add tests

### DIFF
--- a/verifications/ed25519/key.go
+++ b/verifications/ed25519/key.go
@@ -5,8 +5,7 @@ import (
 	"crypto/rand"
 	"fmt"
 
-	mbase "github.com/multiformats/go-multibase"
-	"github.com/multiformats/go-varint"
+	"github.com/INFURA/go-did/verifications/internal"
 )
 
 type PublicKey = ed25519.PublicKey
@@ -25,7 +24,7 @@ func GenerateKeyPair() (PublicKey, PrivateKey, error) {
 	return ed25519.GenerateKey(rand.Reader)
 }
 
-// PublicKeyFromBytes convert a serialized public key to a PublicKey.
+// PublicKeyFromBytes converts a serialized public key to a PublicKey.
 // It errors if the slice is not the right size.
 func PublicKeyFromBytes(b []byte) (PublicKey, error) {
 	if len(b) != PublicKeySize {
@@ -36,38 +35,25 @@ func PublicKeyFromBytes(b []byte) (PublicKey, error) {
 
 // PublicKeyFromMultibase decodes the public key from its Multibase form
 func PublicKeyFromMultibase(multibase string) (PublicKey, error) {
-	baseCodec, bytes, err := mbase.Decode(multibase)
-	if err != nil {
-		return nil, err
-	}
-	// the specification enforces that encoding
-	if baseCodec != mbase.Base58BTC {
-		return nil, fmt.Errorf("not Base58BTC encoded")
-	}
-	code, read, err := varint.FromUvarint(bytes)
+	code, bytes, err := helpers.MultibaseDecode(multibase)
 	if err != nil {
 		return nil, err
 	}
 	if code != MultibaseCode {
 		return nil, fmt.Errorf("invalid code")
 	}
-	if read != 2 {
-		return nil, fmt.Errorf("unexpected multibase")
-	}
-	if len(bytes)-read != PublicKeySize {
+	if len(bytes) != PublicKeySize {
 		return nil, fmt.Errorf("invalid ed25519 public key size")
 	}
-	return bytes[read:], nil
+	return bytes, nil
 }
 
 // PublicKeyToMultibase encodes the public key in a suitable way for publicKeyMultibase
 func PublicKeyToMultibase(pub PublicKey) string {
-	// can only fail with an invalid encoding, but it's hardcoded
-	bytes, _ := mbase.Encode(mbase.Base58BTC, append(varint.ToUvarint(MultibaseCode), pub...))
-	return bytes
+	return helpers.MultibaseEncode(MultibaseCode, pub)
 }
 
-// PrivateKeyFromBytes convert a serialized public key to a PrivateKey.
+// PrivateKeyFromBytes converts a serialized public key to a PrivateKey.
 // It errors if the slice is not the right size.
 func PrivateKeyFromBytes(b []byte) (PrivateKey, error) {
 	if len(b) != ed25519.PrivateKeySize {

--- a/verifications/ed25519/key_test.go
+++ b/verifications/ed25519/key_test.go
@@ -1,0 +1,27 @@
+package ed25519_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/INFURA/go-did/verifications/ed25519"
+)
+
+func TestGenerateKey(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKeyPair()
+	require.NoError(t, err)
+	require.NotNil(t, pub)
+	require.NotNil(t, priv)
+	require.True(t, pub.Equal(priv.Public()))
+}
+
+func TestMultibaseRoundTrip(t *testing.T) {
+	pub, _, err := ed25519.GenerateKeyPair()
+	require.NoError(t, err)
+
+	mb := ed25519.PublicKeyToMultibase(pub)
+	rt, err := ed25519.PublicKeyFromMultibase(mb)
+	require.NoError(t, err)
+	require.Equal(t, pub, rt)
+}

--- a/verifications/internal/multibase.go
+++ b/verifications/internal/multibase.go
@@ -1,0 +1,35 @@
+package helpers
+
+import (
+	"fmt"
+
+	mbase "github.com/multiformats/go-multibase"
+	"github.com/multiformats/go-varint"
+)
+
+// MultibaseDecode is a helper for decoding multibase public keys.
+func MultibaseDecode(multibase string) (uint64, []byte, error) {
+	baseCodec, bytes, err := mbase.Decode(multibase)
+	if err != nil {
+		return 0, nil, err
+	}
+	// the specification enforces that encoding
+	if baseCodec != mbase.Base58BTC {
+		return 0, nil, fmt.Errorf("not Base58BTC encoded")
+	}
+	code, read, err := varint.FromUvarint(bytes)
+	if err != nil {
+		return 0, nil, err
+	}
+	if read != 2 {
+		return 0, nil, fmt.Errorf("unexpected multibase")
+	}
+	return code, bytes[read:], nil
+}
+
+// MultibaseEncode is a helper for encoding multibase public keys.
+func MultibaseEncode(code uint64, bytes []byte) string {
+	// can only fail with an invalid encoding, but it's hardcoded
+	res, _ := mbase.Encode(mbase.Base58BTC, append(varint.ToUvarint(code), bytes...))
+	return res
+}


### PR DESCRIPTION
This also add the ed25519->x25519 conversion for private keys, notably to make sure that it matches with the conversion for public keys.