### PR TITLE
ed25519,x25519: fix possible bad public key conversion

### DIFF
--- a/crypto/ed25519/public.go
+++ b/crypto/ed25519/public.go
@@ -55,7 +55,11 @@ func PublicKeyFromX509DER(bytes []byte) (PublicKey, error) {
 	if err != nil {
 		return PublicKey{}, err
 	}
-	return PublicKey{k: pub.(ed25519.PublicKey)}, nil
+	ed25519Pub, ok := pub.(ed25519.PublicKey)
+	if !ok {
+		return PublicKey{}, fmt.Errorf("invalid ed25519 public key type")
+	}
+	return PublicKey{k: ed25519Pub}, nil
 }
 
 // PublicKeyFromX509PEM decodes an X.509 PEM (string) encoded public key.

--- a/crypto/ed25519/public.go
+++ b/crypto/ed25519/public.go
@@ -59,6 +59,9 @@ func PublicKeyFromX509DER(bytes []byte) (PublicKey, error) {
 	if !ok {
 		return PublicKey{}, fmt.Errorf("invalid ed25519 public key type")
 	}
+	if len(ed25519Pub) != PublicKeyBytesSize {
+		return PublicKey{}, fmt.Errorf("invalid ed25519 public key size")
+	}
 	return PublicKey{k: ed25519Pub}, nil
 }
 

--- a/crypto/x25519/public.go
+++ b/crypto/x25519/public.go
@@ -104,7 +104,11 @@ func PublicKeyFromX509DER(bytes []byte) (*PublicKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &PublicKey{k: pub.(*ecdh.PublicKey)}, nil
+	ecdhPub, ok := pub.(*ecdh.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("invalid x25519 public key type")
+	}
+	return &PublicKey{k: ecdhPub}, nil
 }
 
 // PublicKeyFromX509PEM decodes an X.509 PEM (string) encoded public key.

--- a/crypto/x25519/public.go
+++ b/crypto/x25519/public.go
@@ -108,6 +108,13 @@ func PublicKeyFromX509DER(bytes []byte) (*PublicKey, error) {
 	if !ok {
 		return nil, fmt.Errorf("invalid x25519 public key type")
 	}
+	if ecdhPub.Curve() != ecdh.X25519() {
+		return nil, fmt.Errorf("invalid x25519 curve")
+	}
+	keyBytes := ecdhPub.Bytes()
+	if len(keyBytes) != PublicKeyBytesSize {
+		return nil, fmt.Errorf("invalid x25519 public key size")
+	}
 	return &PublicKey{k: ecdhPub}, nil
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches cryptographic key parsing: invalid or unexpected X.509 public keys now error instead of panicking or being accepted, which could affect callers relying on previous lax behavior.
> 
> **Overview**
> Hardens X.509 public key decoding for `ed25519` and `x25519` by replacing unchecked type assertions with explicit type checks and clear errors.
> 
> Adds validation that the parsed key is the expected algorithm (and curve for X25519) and that the raw key material is the expected length before constructing the library `PublicKey` wrappers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0c985a2e094b1ec891fe9df3b84c48b5d16ab04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->