### PR TITLE
secp256k1: add constants for compact signature size

### DIFF
--- a/crypto/secp256k1/key.go
+++ b/crypto/secp256k1/key.go
@@ -13,6 +13,11 @@ const (
 	PrivateKeyBytesSize = secp256k1.PrivKeyBytesLen
 	// SignatureBytesSize is the size, in bytes, of signatures in raw bytes.
 	SignatureBytesSize = 64
+	// SignatureCompactBytesSize is the size, in bytes, of "compact" signatures.
+	// The term "compact" is misleading and refers to the fact that the extra byte
+	// allows reconstructing the public key from the signature and therefore avoids
+	// having to transmit the public key. The signature itself is slightly bigger.
+	SignatureCompactBytesSize = 65
 
 	MultibaseCode = uint64(0xe7)
 

--- a/crypto/secp256k1/public.go
+++ b/crypto/secp256k1/public.go
@@ -57,8 +57,8 @@ func PublicKeyFromXY(x, y []byte) (*PublicKey, error) {
 // The hash must be 32 bytes long and be the one used for that signature.
 // Returns an error if recovery fails or the signature is malformed.
 func PublicKeyFromRecovery(signature []byte, hash []byte) (*PublicKey, error) {
-	if len(signature) != 65 {
-		return nil, fmt.Errorf("secp256k1: invalid compact signature length: expected 65 bytes, got %d", len(signature))
+	if len(signature) != SignatureCompactBytesSize {
+		return nil, fmt.Errorf("secp256k1: invalid compact signature length: expected %d bytes, got %d", SignatureCompactBytesSize, len(signature))
 	}
 	if len(hash) != 32 {
 		return nil, fmt.Errorf("secp256k1: invalid hash length: expected 32 bytes, got %d", len(hash))


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds a size constant and uses it for input validation/error messages without changing signature recovery behavior.
> 
> **Overview**
> Adds `SignatureCompactBytesSize` (65 bytes) to the secp256k1 crypto package and documents the meaning of “compact” signatures.
> 
> Updates `PublicKeyFromRecovery` to validate compact signature length against this constant and to use it in the error message, replacing the previous hard-coded `65`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 448728b38fc24242160de7024bfedfaf6184e4ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->