### PR TITLE
secp256k1: add explicit compressed/uncompressed pubkey serialisation

### DIFF
--- a/crypto/secp256k1/key_test.go
+++ b/crypto/secp256k1/key_test.go
@@ -140,6 +140,26 @@ func TestPublicKeyFromCompactRecovery(t *testing.T) {
 	require.True(t, pub.Equal(recovered))
 }
 
+func TestPublicKeyFromBytesEncodings(t *testing.T) {
+	pub, _, err := GenerateKeyPair()
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name     string
+		encoding []byte
+	}{
+		{"compressed (ToBytes)", pub.ToBytes()},
+		{"compressed (CompressedBytes)", pub.CompressedBytes()},
+		{"uncompressed (UncompressedBytes)", pub.UncompressedBytes()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := PublicKeyFromBytes(tc.encoding)
+			require.NoError(t, err)
+			require.True(t, pub.Equal(got))
+		})
+	}
+}
+
 func TestSignatureASN1(t *testing.T) {
 	// openssl ecparam -genkey -name secp256k1 -noout -out private.pem
 	// openssl ec -in private.pem -pubout -out public.pem

--- a/crypto/secp256k1/public.go
+++ b/crypto/secp256k1/public.go
@@ -149,6 +149,20 @@ func (p *PublicKey) YBytes() []byte {
 	return buf[:]
 }
 
+// CompressedBytes returns the SEC1 compressed public key: 0x02 or 0x03 || X(32) (33 bytes).
+// Use this when interoperating with Bitcoin/Lightning or any format that requires explicit
+// compressed encoding. If you need just the default serialization, use ToBytes().
+func (p *PublicKey) CompressedBytes() []byte {
+	return p.k.SerializeCompressed()
+}
+
+// UncompressedBytes returns the SEC1 uncompressed public key: 0x04 || X(32) || Y(32) (65 bytes).
+// Use this when interoperating with TLS/X.509, ECDH, or any library that speaks SEC1.
+// If you need just the raw coordinates, use XBytes() and YBytes().
+func (p *PublicKey) UncompressedBytes() []byte {
+	return p.k.SerializeUncompressed()
+}
+
 func (p *PublicKey) Equal(other crypto.PublicKey) bool {
 	if other, ok := other.(*PublicKey); ok {
 		return p.k.IsEqual(other.k)
@@ -156,8 +170,8 @@ func (p *PublicKey) Equal(other crypto.PublicKey) bool {
 	return false
 }
 
+// ToBytes returns the compressed public key. Same as CompressedBytes().
 func (p *PublicKey) ToBytes() []byte {
-	// 33-byte compressed format
 	return p.k.SerializeCompressed()
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds explicit serialization helpers and a small unit test without changing existing serialization behavior (`ToBytes` remains compressed).
> 
> **Overview**
> Adds explicit `PublicKey.CompressedBytes()` and `PublicKey.UncompressedBytes()` helpers (SEC1 33-byte and 65-byte encodings) and documents that `ToBytes()` is the compressed form.
> 
> Extends tests with `TestPublicKeyFromBytesEncodings` to ensure `PublicKeyFromBytes` can round-trip both compressed and uncompressed encodings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd0d3530d2cf1c5dbebb31e2b7fe968c0237d93c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->