### PR TITLE
crypto: support pre-hashed signing/verify

### DIFF
--- a/crypto/_testsuite/testsuite.go
+++ b/crypto/_testsuite/testsuite.go
@@ -31,8 +31,9 @@ type TestHarness[PubT crypto.PublicKey, PrivT crypto.PrivateKey] struct {
 
 	MultibaseCode uint64
 
-	DefaultHash crypto.Hash
-	OtherHashes []crypto.Hash
+	DefaultHash       crypto.Hash
+	OtherHashes       []crypto.Hash
+	SupportsPreHashed bool
 
 	PublicKeyBytesSize  int
 	PrivateKeyBytesSize int
@@ -330,6 +331,37 @@ func TestSuite[PubT crypto.PublicKey, PrivT crypto.PrivateKey](t *testing.T, har
 					require.False(t, valid)
 				})
 			}
+
+			t.Run(tc.name+"-Prehashed", func(t *testing.T) {
+				msg := []byte("message")
+
+				if harness.SupportsPreHashed {
+					// Pre-hash the message with the default hash, then sign and verify the digest directly.
+					h := tc.defaultHash.New()
+					h.Write(msg)
+					digest := h.Sum(nil)
+
+					sig, err := tc.signer(digest, crypto.WithSigningPreHashed())
+					require.NoError(t, err)
+					require.NotEmpty(t, sig)
+
+					valid := tc.verifier(digest, sig, crypto.WithSigningPreHashed())
+					require.True(t, valid)
+
+					// Wrong digest must not verify.
+					wrong := make([]byte, len(digest))
+					valid = tc.verifier(wrong, sig, crypto.WithSigningPreHashed())
+					require.False(t, valid)
+				} else {
+					// Key type does not support PREHASHED: sign must return an error,
+					// verify must return false.
+					_, err := tc.signer(msg, crypto.WithSigningPreHashed())
+					require.Error(t, err)
+
+					valid := tc.verifier(msg, []byte("fake"), crypto.WithSigningPreHashed())
+					require.False(t, valid)
+				}
+			})
 		}
 	})
 

--- a/crypto/ed25519/key_test.go
+++ b/crypto/ed25519/key_test.go
@@ -25,6 +25,7 @@ var harness = testsuite.TestHarness[PublicKey, PrivateKey]{
 	MultibaseCode:                   MultibaseCode,
 	DefaultHash:                     crypto.SHA512,
 	OtherHashes:                     nil,
+	SupportsPreHashed:               false,
 	PublicKeyBytesSize:              PublicKeyBytesSize,
 	PrivateKeyBytesSize:             PrivateKeyBytesSize,
 	SignatureBytesSize:              SignatureBytesSize,

--- a/crypto/hash.go
+++ b/crypto/hash.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/ucan-wg/go-varsig"
 	"golang.org/x/crypto/sha3"
+
+	helpers "github.com/MetaMask/go-did-it/crypto/internal"
 )
 
 // As the standard crypto library prohibits from registering additional hash algorithm (like keccak),
@@ -40,6 +42,11 @@ const (
 	maxStdHash
 
 	// Extensions
+
+	// PREHASHED signals that the message is already a digest — no hashing is applied.
+	// The caller is responsible for passing a correctly sized digest for the chosen key type.
+	// Note: PREHASHED has no varsig representation and is not supported by some key types.
+	PREHASHED
 	KECCAK_256
 	KECCAK_512
 
@@ -81,6 +88,9 @@ func (h Hash) New() hash.Hash {
 func (h Hash) ToVarsigHash() varsig.Hash {
 	if h == MD5SHA1 {
 		panic("no multihash/multicodec value exists for MD5+SHA1")
+	}
+	if h == PREHASHED {
+		panic("PREHASHED has no varsig hash representation")
 	}
 	if h < maxHash {
 		return hashVarsigs[h]
@@ -137,10 +147,12 @@ func FromVarsigHash(h varsig.Hash) Hash {
 }
 
 var hashNames = []string{
+	"Prehashed",
 	"Keccak-256",
 	"Keccak-512",
 }
 var hashFns = []func() hash.Hash{
+	helpers.NewPreHashedHasher,
 	sha3.NewLegacyKeccak256,
 	sha3.NewLegacyKeccak512,
 }
@@ -166,6 +178,7 @@ var hashVarsigs = []varsig.Hash{
 	varsig.HashBlake2b_384,
 	varsig.HashBlake2b_512,
 	0, // maxStdHash
+	0, // PREHASHED - no varsig representation; ToVarsigHash panics before reaching here
 	varsig.HashKeccak_256,
 	varsig.HashKeccak_512,
 }

--- a/crypto/internal/hash.go
+++ b/crypto/internal/hash.go
@@ -1,0 +1,37 @@
+package helpers
+
+import "hash"
+
+var _ hash.Hash = &preHashedHasher{}
+
+// preHashedHasher is an identity hash.Hash: Write accumulates bytes, Sum returns them as-is.
+// Used with PREHASHED to pass a pre-computed digest through the standard hashing pattern
+// without any additional transformation.
+type preHashedHasher struct {
+	buf []byte
+}
+
+func NewPreHashedHasher() hash.Hash {
+	return &preHashedHasher{}
+}
+
+func (h *preHashedHasher) Write(p []byte) (int, error) {
+	h.buf = append(h.buf, p...)
+	return len(p), nil
+}
+
+func (h *preHashedHasher) Sum(b []byte) []byte {
+	return append(b, h.buf...)
+}
+
+func (h *preHashedHasher) Reset() {
+	h.buf = h.buf[:0]
+}
+
+func (h *preHashedHasher) Size() int {
+	return -1
+}
+
+func (h *preHashedHasher) BlockSize() int {
+	return 1
+}

--- a/crypto/options.go
+++ b/crypto/options.go
@@ -67,6 +67,16 @@ func WithSigningHash(hash Hash) SigningOption {
 	}
 }
 
+// WithSigningPreHashed specify that the signing message was pre-hashed.
+// When using this option, the caller is responsible for providing a pre-computed digest
+// suitable for the key type.
+// This is the same as WithSigningHash(PREHASHED).
+func WithSigningPreHashed() SigningOption {
+	return func(opts *SigningOpts) {
+		opts.hash = PREHASHED
+	}
+}
+
 // WithPayloadEncoding specify the encoding that was used on the message before signing it.
 // This will be included in the resulting varsig.
 func WithPayloadEncoding(encoding varsig.PayloadEncoding) SigningOption {

--- a/crypto/p256/key_test.go
+++ b/crypto/p256/key_test.go
@@ -23,6 +23,7 @@ var harness = testsuite.TestHarness[*PublicKey, *PrivateKey]{
 	MultibaseCode:                   MultibaseCode,
 	DefaultHash:                     crypto.SHA256,
 	OtherHashes:                     []crypto.Hash{crypto.SHA224, crypto.SHA384, crypto.SHA512},
+	SupportsPreHashed:               true,
 	PublicKeyBytesSize:              PublicKeyBytesSize,
 	PrivateKeyBytesSize:             PrivateKeyBytesSize,
 	SignatureBytesSize:              SignatureBytesSize,

--- a/crypto/p384/key_test.go
+++ b/crypto/p384/key_test.go
@@ -20,6 +20,7 @@ var harness = testsuite.TestHarness[*PublicKey, *PrivateKey]{
 	MultibaseCode:                   MultibaseCode,
 	DefaultHash:                     crypto.SHA384,
 	OtherHashes:                     []crypto.Hash{crypto.SHA256, crypto.SHA512},
+	SupportsPreHashed:               true,
 	PublicKeyBytesSize:              PublicKeyBytesSize,
 	PrivateKeyBytesSize:             PrivateKeyBytesSize,
 	SignatureBytesSize:              SignatureBytesSize,

--- a/crypto/p521/key_test.go
+++ b/crypto/p521/key_test.go
@@ -20,6 +20,7 @@ var harness = testsuite.TestHarness[*PublicKey, *PrivateKey]{
 	MultibaseCode:                   MultibaseCode,
 	DefaultHash:                     crypto.SHA512,
 	OtherHashes:                     []crypto.Hash{crypto.SHA384},
+	SupportsPreHashed:               true,
 	PublicKeyBytesSize:              PublicKeyBytesSize,
 	PrivateKeyBytesSize:             PrivateKeyBytesSize,
 	SignatureBytesSize:              SignatureBytesSize,

--- a/crypto/rsa/key_test.go
+++ b/crypto/rsa/key_test.go
@@ -21,6 +21,7 @@ var harness2048 = testsuite.TestHarness[*PublicKey, *PrivateKey]{
 	MultibaseCode:                   MultibaseCode,
 	DefaultHash:                     crypto.SHA256,
 	OtherHashes:                     []crypto.Hash{crypto.SHA384, crypto.SHA512},
+	SupportsPreHashed:               false,
 }
 
 var harness3072 = testsuite.TestHarness[*PublicKey, *PrivateKey]{
@@ -34,6 +35,7 @@ var harness3072 = testsuite.TestHarness[*PublicKey, *PrivateKey]{
 	MultibaseCode:                   MultibaseCode,
 	DefaultHash:                     crypto.SHA384,
 	OtherHashes:                     []crypto.Hash{crypto.SHA512},
+	SupportsPreHashed:               false,
 }
 
 var harness4096 = testsuite.TestHarness[*PublicKey, *PrivateKey]{
@@ -47,6 +49,7 @@ var harness4096 = testsuite.TestHarness[*PublicKey, *PrivateKey]{
 	MultibaseCode:                   MultibaseCode,
 	DefaultHash:                     crypto.SHA512,
 	OtherHashes:                     []crypto.Hash{},
+	SupportsPreHashed:               false,
 }
 
 func TestSuite2048(t *testing.T) {

--- a/crypto/rsa/private.go
+++ b/crypto/rsa/private.go
@@ -170,6 +170,9 @@ func (p *PrivateKey) SignToASN1(message []byte, opts ...crypto.SigningOption) ([
 	params := crypto.CollectSigningOptions(opts)
 
 	hashCode := params.HashOrDefault(defaultSigHash(p.k.N.BitLen()))
+	if hashCode == crypto.PREHASHED {
+		return nil, fmt.Errorf("rsa: PREHASHED is not supported")
+	}
 	hasher := hashCode.New()
 	hasher.Write(message)
 	hash := hasher.Sum(nil)

--- a/crypto/rsa/public.go
+++ b/crypto/rsa/public.go
@@ -146,6 +146,9 @@ func (p *PublicKey) VerifyASN1(message, signature []byte, opts ...crypto.Signing
 	}
 
 	hashCode := params.HashOrDefault(defaultSigHash(p.k.N.BitLen()))
+	if hashCode == crypto.PREHASHED {
+		return false
+	}
 	hasher := hashCode.New()
 	hasher.Write(message)
 	hash := hasher.Sum(nil)

--- a/crypto/secp256k1/key_test.go
+++ b/crypto/secp256k1/key_test.go
@@ -27,6 +27,7 @@ var harness = testsuite.TestHarness[*PublicKey, *PrivateKey]{
 	MultibaseCode:                   MultibaseCode,
 	DefaultHash:                     crypto.SHA256,
 	OtherHashes:                     []crypto.Hash{crypto.KECCAK_256},
+	SupportsPreHashed:               true,
 	PublicKeyBytesSize:              PublicKeyBytesSize,
 	PrivateKeyBytesSize:             PrivateKeyBytesSize,
 	SignatureBytesSize:              SignatureBytesSize,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches signature option parsing and hash selection, which can subtly affect signing/verification behavior across algorithms. RSA explicitly rejects `PREHASHED`, but other key types now exercise new code paths that must be validated for correctness and interoperability.
> 
> **Overview**
> Introduces a new `crypto.PREHASHED` hash mode plus `WithSigningPreHashed()` to allow signing/verification when the caller provides an already-hashed digest (no additional hashing applied).
> 
> Updates the shared crypto test harness to run a *prehashed* sign/verify scenario and adds per-algorithm support flags (ECDSA curves and `secp256k1` enabled; `ed25519` and `rsa` disabled). RSA `SignToASN1`/`VerifyASN1` now explicitly error/return false when `PREHASHED` is requested.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1700a138cae7a884baf3d01697274e62f7a21a42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->