### PR TITLE
ecdsa: option to enforce low-S signature (sign+verify)

### DIFF
--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu" ]
-        go: [ "1.22.x", "1.23.x", ]
+        go: [ "1.25.x", "1.26.x", ]
     env:
       COVERAGES: ""
     runs-on: ${{ matrix.os }}-latest

--- a/crypto/_testsuite/testsuite.go
+++ b/crypto/_testsuite/testsuite.go
@@ -1,7 +1,9 @@
 package testsuite
 
 import (
+	"encoding/asn1"
 	"fmt"
+	"math/big"
 	"strings"
 	"testing"
 	"text/tabwriter"
@@ -689,6 +691,69 @@ func BenchSuite[PubT crypto.PublicKey, PrivT crypto.PrivateKey](b *testing.B, ha
 			}
 		})
 	})
+}
+
+// TestEcdsaLowSSuite tests low-S signing and verification for ECDSA key types.
+// curveOrder is the group order N of the curve (used to construct high-S test vectors).
+// Call this from each ECDSA key's test file alongside TestSuite.
+func TestEcdsaLowSSuite[PubT crypto.PublicKey, PrivT crypto.PrivateKey](t *testing.T, harness TestHarness[PubT, PrivT], curveOrder *big.Int) {
+	t.Helper()
+	n := curveOrder
+	halfN := new(big.Int).Rsh(n, 1)
+	msg := []byte("message")
+
+	pub, priv, err := harness.GenerateKeyPair()
+	require.NoError(t, err)
+
+	if implements[PubT, crypto.PublicKeySigningBytes]() {
+		t.Run("Bytes", func(t *testing.T) {
+			spub := (crypto.PublicKey(pub)).(crypto.PublicKeySigningBytes)
+			spriv := (crypto.PrivateKey(priv)).(crypto.PrivateKeySigningBytes)
+			half := harness.SignatureBytesSize / 2
+
+			// low-S signature must verify with and without the option
+			sig, err := spriv.SignToBytes(msg, crypto.WithEcdsaLowSSig())
+			require.NoError(t, err)
+			s := new(big.Int).SetBytes(sig[half:])
+			require.True(t, s.Cmp(halfN) <= 0, "signature produced with WithEcdsaLowSSig must have s ≤ N/2")
+			require.True(t, spub.VerifyBytes(msg, sig, crypto.WithEcdsaLowSSig()))
+			require.True(t, spub.VerifyBytes(msg, sig))
+
+			// flip to high-S: s' = N - s
+			highS := new(big.Int).Sub(n, s)
+			highSig := make([]byte, harness.SignatureBytesSize)
+			copy(highSig[:half], sig[:half])
+			highS.FillBytes(highSig[half:])
+
+			require.False(t, spub.VerifyBytes(msg, highSig, crypto.WithEcdsaLowSSig()), "high-S must be rejected with WithEcdsaLowSSig")
+			require.True(t, spub.VerifyBytes(msg, highSig), "high-S must be accepted without WithEcdsaLowSSig")
+		})
+	}
+
+	if implements[PubT, crypto.PublicKeySigningASN1]() {
+		t.Run("ASN1", func(t *testing.T) {
+			spub := (crypto.PublicKey(pub)).(crypto.PublicKeySigningASN1)
+			spriv := (crypto.PrivateKey(priv)).(crypto.PrivateKeySigningASN1)
+
+			// low-S signature must verify with and without the option
+			sig, err := spriv.SignToASN1(msg, crypto.WithEcdsaLowSSig())
+			require.NoError(t, err)
+			var parsed struct{ R, S *big.Int }
+			_, err = asn1.Unmarshal(sig, &parsed)
+			require.NoError(t, err)
+			require.True(t, parsed.S.Cmp(halfN) <= 0, "signature produced with WithEcdsaLowSSig must have s ≤ N/2")
+			require.True(t, spub.VerifyASN1(msg, sig, crypto.WithEcdsaLowSSig()))
+			require.True(t, spub.VerifyASN1(msg, sig))
+
+			// flip to high-S: s' = N - s
+			highS := new(big.Int).Sub(n, parsed.S)
+			highSig, err := asn1.Marshal(struct{ R, S *big.Int }{parsed.R, highS})
+			require.NoError(t, err)
+
+			require.False(t, spub.VerifyASN1(msg, highSig, crypto.WithEcdsaLowSSig()), "high-S must be rejected with WithEcdsaLowSSig")
+			require.True(t, spub.VerifyASN1(msg, highSig), "high-S must be accepted without WithEcdsaLowSSig")
+		})
+	}
 }
 
 func implements[T, I any]() bool {

--- a/crypto/internal/asn1.go
+++ b/crypto/internal/asn1.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"errors"
+	"math/big"
 
 	"golang.org/x/crypto/cryptobyte"
 	"golang.org/x/crypto/cryptobyte/asn1"
@@ -34,4 +35,20 @@ func addASN1IntBytes(b *cryptobyte.Builder, bytes []byte) {
 		}
 		c.AddBytes(bytes)
 	})
+}
+
+// DecodeSignatureFromASN1 parses a DER-encoded ECDSA signature and returns
+// R and S as big.Ints.
+func DecodeSignatureFromASN1(sig []byte) (r, s *big.Int, err error) {
+	input := cryptobyte.String(sig)
+	var inner cryptobyte.String
+	if !input.ReadASN1(&inner, asn1.SEQUENCE) || !input.Empty() {
+		return nil, nil, errors.New("invalid ASN.1 signature")
+	}
+	r = new(big.Int)
+	s = new(big.Int)
+	if !inner.ReadASN1Integer(r) || !inner.ReadASN1Integer(s) || !inner.Empty() {
+		return nil, nil, errors.New("invalid ASN.1 signature integers")
+	}
+	return r, s, nil
 }

--- a/crypto/options.go
+++ b/crypto/options.go
@@ -8,6 +8,7 @@ import (
 type SigningOpts struct {
 	hash            Hash
 	payloadEncoding varsig.PayloadEncoding
+	ecdsaLowS       bool
 
 	// if WithVarsig is used
 	algo   varsig.Algorithm
@@ -58,6 +59,9 @@ func (opts SigningOpts) VarsigMatch(algo varsig.Algorithm, curve uint64, keyLeng
 	}
 }
 
+// EcdsaLowS returns true if the ECDSA low-S signature enforcement was requested.
+func (opts SigningOpts) EcdsaLowS() bool { return opts.ecdsaLowS }
+
 type SigningOption func(opts *SigningOpts)
 
 // WithSigningHash specify the hash algorithm to be used for signatures
@@ -74,6 +78,15 @@ func WithSigningHash(hash Hash) SigningOption {
 func WithSigningPreHashed() SigningOption {
 	return func(opts *SigningOpts) {
 		opts.hash = PREHASHED
+	}
+}
+
+// WithEcdsaLowSSig requests that the produced ECDSA signature be normalised to low-S
+// canonical form (s ≤ N/2).
+// secp256k1 always produces low-S signatures.
+func WithEcdsaLowSSig() SigningOption {
+	return func(opts *SigningOpts) {
+		opts.ecdsaLowS = true
 	}
 }
 

--- a/crypto/p256/key_test.go
+++ b/crypto/p256/key_test.go
@@ -1,6 +1,7 @@
 package p256
 
 import (
+	"crypto/elliptic"
 	"encoding/base64"
 	"testing"
 
@@ -31,6 +32,10 @@ var harness = testsuite.TestHarness[*PublicKey, *PrivateKey]{
 
 func TestSuite(t *testing.T) {
 	testsuite.TestSuite(t, harness)
+}
+
+func TestEcdsaLowS(t *testing.T) {
+	testsuite.TestEcdsaLowSSuite(t, harness, elliptic.P256().Params().N)
 }
 
 func BenchmarkSuite(b *testing.B) {

--- a/crypto/p256/private.go
+++ b/crypto/p256/private.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ucan-wg/go-varsig"
 
 	"github.com/MetaMask/go-did-it/crypto"
+	helpers "github.com/MetaMask/go-did-it/crypto/internal"
 )
 
 var _ crypto.PrivateKeySigningBytes = &PrivateKey{}
@@ -122,6 +123,15 @@ func (p *PrivateKey) SignToBytes(message []byte, opts ...crypto.SigningOption) (
 		return nil, err
 	}
 
+	if params.EcdsaLowS() {
+		n := p.k.Curve.Params().N
+		// new(big.Int).Rsh(n, 1) is n>>1, which is N/2,
+		// so this is "if s > N/2"
+		if s.Cmp(new(big.Int).Rsh(n, 1)) > 0 {
+			s.Sub(n, s)
+		}
+	}
+
 	sig := make([]byte, SignatureBytesSize)
 	r.FillBytes(sig[:SignatureBytesSize/2])
 	s.FillBytes(sig[SignatureBytesSize/2:])
@@ -137,7 +147,19 @@ func (p *PrivateKey) SignToASN1(message []byte, opts ...crypto.SigningOption) ([
 	hasher.Write(message)
 	hash := hasher.Sum(nil)
 
-	return ecdsa.SignASN1(rand.Reader, p.k, hash[:])
+	r, s, err := ecdsa.Sign(rand.Reader, p.k, hash[:])
+	if err != nil {
+		return nil, err
+	}
+	if params.EcdsaLowS() {
+		n := p.k.Curve.Params().N
+		// new(big.Int).Rsh(n, 1) is n>>1, which is N/2,
+		// so this is "if s > N/2"
+		if s.Cmp(new(big.Int).Rsh(n, 1)) > 0 {
+			s.Sub(n, s)
+		}
+	}
+	return helpers.EncodeSignatureToASN1(r.Bytes(), s.Bytes())
 }
 
 func (p *PrivateKey) PublicKeyIsCompatible(remote crypto.PublicKey) bool {

--- a/crypto/p256/public.go
+++ b/crypto/p256/public.go
@@ -137,6 +137,18 @@ func (p *PublicKey) VerifyBytes(message, signature []byte, opts ...crypto.Signin
 		return false
 	}
 
+	params := crypto.CollectSigningOptions(opts)
+
+	// The raw r||s form lets us check low-S directly, without decoding.
+	if params.EcdsaLowS() {
+		s := new(big.Int).SetBytes(signature[SignatureBytesSize/2:])
+		// new(big.Int).Rsh(N, 1) is N>>1, which is N/2,
+		// so this is "if s > N/2", i.e. reject high-S signatures
+		if s.Cmp(new(big.Int).Rsh(p.k.Curve.Params().N, 1)) > 0 {
+			return false
+		}
+	}
+
 	// For some reason, the go crypto library in ecdsa.Verify() encodes the signature as ASN.1 to then decode it.
 	// This means it's actually more efficient to encode the signature as ASN.1 here.
 	sigAsn1, err := helpers.EncodeSignatureToASN1(signature[:SignatureBytesSize/2], signature[SignatureBytesSize/2:])
@@ -144,13 +156,29 @@ func (p *PublicKey) VerifyBytes(message, signature []byte, opts ...crypto.Signin
 		return false
 	}
 
-	return p.VerifyASN1(message, sigAsn1, opts...)
+	return p.verify(params, message, sigAsn1)
 }
 
 // The default signing hash is SHA-256.
 func (p *PublicKey) VerifyASN1(message, signature []byte, opts ...crypto.SigningOption) bool {
 	params := crypto.CollectSigningOptions(opts)
 
+	if params.EcdsaLowS() {
+		_, s, err := helpers.DecodeSignatureFromASN1(signature)
+		// new(big.Int).Rsh(N, 1) is N>>1, which is N/2,
+		// so this is "if s > N/2", i.e. reject high-S signatures
+		if err != nil || s.Cmp(new(big.Int).Rsh(p.k.Curve.Params().N, 1)) > 0 {
+			return false
+		}
+	}
+
+	return p.verify(params, message, signature)
+}
+
+// verify checks the varsig constraints and the ASN.1 signature. Low-S enforcement,
+// if requested, is done by the exported VerifyBytes/VerifyASN1 from their respective
+// signature forms, so it is not repeated here.
+func (p *PublicKey) verify(params crypto.SigningOpts, message, sigAsn1 []byte) bool {
 	if !params.VarsigMatch(varsig.AlgorithmECDSA, uint64(varsig.CurveP256), 0) {
 		return false
 	}
@@ -159,7 +187,7 @@ func (p *PublicKey) VerifyASN1(message, signature []byte, opts ...crypto.Signing
 	hasher.Write(message)
 	hash := hasher.Sum(nil)
 
-	return ecdsa.VerifyASN1(p.k, hash[:], signature)
+	return ecdsa.VerifyASN1(p.k, hash, sigAsn1)
 }
 
 // Unwrap returns the underlying crypto/ecdsa public key.

--- a/crypto/p384/key_test.go
+++ b/crypto/p384/key_test.go
@@ -1,6 +1,7 @@
 package p384
 
 import (
+	"crypto/elliptic"
 	"testing"
 
 	"github.com/MetaMask/go-did-it/crypto"
@@ -28,6 +29,10 @@ var harness = testsuite.TestHarness[*PublicKey, *PrivateKey]{
 
 func TestSuite(t *testing.T) {
 	testsuite.TestSuite(t, harness)
+}
+
+func TestEcdsaLowS(t *testing.T) {
+	testsuite.TestEcdsaLowSSuite(t, harness, elliptic.P384().Params().N)
 }
 
 func BenchmarkSuite(b *testing.B) {

--- a/crypto/p384/private.go
+++ b/crypto/p384/private.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ucan-wg/go-varsig"
 
 	"github.com/MetaMask/go-did-it/crypto"
+	helpers "github.com/MetaMask/go-did-it/crypto/internal"
 )
 
 var _ crypto.PrivateKeySigningBytes = &PrivateKey{}
@@ -122,6 +123,15 @@ func (p *PrivateKey) SignToBytes(message []byte, opts ...crypto.SigningOption) (
 		return nil, err
 	}
 
+	if params.EcdsaLowS() {
+		n := p.k.Curve.Params().N
+		// new(big.Int).Rsh(n, 1) is n>>1, which is N/2,
+		// so this is "if s > N/2"
+		if s.Cmp(new(big.Int).Rsh(n, 1)) > 0 {
+			s.Sub(n, s)
+		}
+	}
+
 	sig := make([]byte, SignatureBytesSize)
 	r.FillBytes(sig[:SignatureBytesSize/2])
 	s.FillBytes(sig[SignatureBytesSize/2:])
@@ -137,7 +147,19 @@ func (p *PrivateKey) SignToASN1(message []byte, opts ...crypto.SigningOption) ([
 	hasher.Write(message)
 	hash := hasher.Sum(nil)
 
-	return ecdsa.SignASN1(rand.Reader, p.k, hash[:])
+	r, s, err := ecdsa.Sign(rand.Reader, p.k, hash[:])
+	if err != nil {
+		return nil, err
+	}
+	if params.EcdsaLowS() {
+		n := p.k.Curve.Params().N
+		// new(big.Int).Rsh(n, 1) is n>>1, which is N/2,
+		// so this is "if s > N/2"
+		if s.Cmp(new(big.Int).Rsh(n, 1)) > 0 {
+			s.Sub(n, s)
+		}
+	}
+	return helpers.EncodeSignatureToASN1(r.Bytes(), s.Bytes())
 }
 
 func (p *PrivateKey) PublicKeyIsCompatible(remote crypto.PublicKey) bool {

--- a/crypto/p384/public.go
+++ b/crypto/p384/public.go
@@ -137,6 +137,18 @@ func (p *PublicKey) VerifyBytes(message, signature []byte, opts ...crypto.Signin
 		return false
 	}
 
+	params := crypto.CollectSigningOptions(opts)
+
+	// The raw r||s form lets us check low-S directly, without decoding.
+	if params.EcdsaLowS() {
+		s := new(big.Int).SetBytes(signature[SignatureBytesSize/2:])
+		// new(big.Int).Rsh(N, 1) is N>>1, which is N/2,
+		// so this is "if s > N/2", i.e. reject high-S signatures
+		if s.Cmp(new(big.Int).Rsh(p.k.Curve.Params().N, 1)) > 0 {
+			return false
+		}
+	}
+
 	// For some reason, the go crypto library in ecdsa.Verify() encodes the signature as ASN.1 to then decode it.
 	// This means it's actually more efficient to encode the signature as ASN.1 here.
 	sigAsn1, err := helpers.EncodeSignatureToASN1(signature[:SignatureBytesSize/2], signature[SignatureBytesSize/2:])
@@ -144,13 +156,29 @@ func (p *PublicKey) VerifyBytes(message, signature []byte, opts ...crypto.Signin
 		return false
 	}
 
-	return p.VerifyASN1(message, sigAsn1, opts...)
+	return p.verify(params, message, sigAsn1)
 }
 
 // The default signing hash is SHA-384.
 func (p *PublicKey) VerifyASN1(message, signature []byte, opts ...crypto.SigningOption) bool {
 	params := crypto.CollectSigningOptions(opts)
 
+	if params.EcdsaLowS() {
+		_, s, err := helpers.DecodeSignatureFromASN1(signature)
+		// new(big.Int).Rsh(N, 1) is N>>1, which is N/2,
+		// so this is "if s > N/2", i.e. reject high-S signatures
+		if err != nil || s.Cmp(new(big.Int).Rsh(p.k.Curve.Params().N, 1)) > 0 {
+			return false
+		}
+	}
+
+	return p.verify(params, message, signature)
+}
+
+// verify checks the varsig constraints and the ASN.1 signature. Low-S enforcement,
+// if requested, is done by the exported VerifyBytes/VerifyASN1 from their respective
+// signature forms, so it is not repeated here.
+func (p *PublicKey) verify(params crypto.SigningOpts, message, sigAsn1 []byte) bool {
 	if !params.VarsigMatch(varsig.AlgorithmECDSA, uint64(varsig.CurveP384), 0) {
 		return false
 	}
@@ -159,7 +187,7 @@ func (p *PublicKey) VerifyASN1(message, signature []byte, opts ...crypto.Signing
 	hasher.Write(message)
 	hash := hasher.Sum(nil)
 
-	return ecdsa.VerifyASN1(p.k, hash[:], signature)
+	return ecdsa.VerifyASN1(p.k, hash, sigAsn1)
 }
 
 // Unwrap returns the underlying crypto/ecdsa public key.

--- a/crypto/p521/key_test.go
+++ b/crypto/p521/key_test.go
@@ -1,6 +1,7 @@
 package p521
 
 import (
+	"crypto/elliptic"
 	"testing"
 
 	"github.com/MetaMask/go-did-it/crypto"
@@ -28,6 +29,10 @@ var harness = testsuite.TestHarness[*PublicKey, *PrivateKey]{
 
 func TestSuite(t *testing.T) {
 	testsuite.TestSuite(t, harness)
+}
+
+func TestEcdsaLowS(t *testing.T) {
+	testsuite.TestEcdsaLowSSuite(t, harness, elliptic.P521().Params().N)
 }
 
 func BenchmarkSuite(b *testing.B) {

--- a/crypto/p521/private.go
+++ b/crypto/p521/private.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ucan-wg/go-varsig"
 
 	"github.com/MetaMask/go-did-it/crypto"
+	helpers "github.com/MetaMask/go-did-it/crypto/internal"
 )
 
 var _ crypto.PrivateKeySigningBytes = &PrivateKey{}
@@ -122,6 +123,15 @@ func (p *PrivateKey) SignToBytes(message []byte, opts ...crypto.SigningOption) (
 		return nil, err
 	}
 
+	if params.EcdsaLowS() {
+		n := p.k.Curve.Params().N
+		// new(big.Int).Rsh(n, 1) is n>>1, which is N/2,
+		// so this is "if s > N/2"
+		if s.Cmp(new(big.Int).Rsh(n, 1)) > 0 {
+			s.Sub(n, s)
+		}
+	}
+
 	sig := make([]byte, SignatureBytesSize)
 	r.FillBytes(sig[:SignatureBytesSize/2])
 	s.FillBytes(sig[SignatureBytesSize/2:])
@@ -137,7 +147,19 @@ func (p *PrivateKey) SignToASN1(message []byte, opts ...crypto.SigningOption) ([
 	hasher.Write(message)
 	hash := hasher.Sum(nil)
 
-	return ecdsa.SignASN1(rand.Reader, p.k, hash[:])
+	r, s, err := ecdsa.Sign(rand.Reader, p.k, hash[:])
+	if err != nil {
+		return nil, err
+	}
+	if params.EcdsaLowS() {
+		n := p.k.Curve.Params().N
+		// new(big.Int).Rsh(n, 1) is n>>1, which is N/2,
+		// so this is "if s > N/2"
+		if s.Cmp(new(big.Int).Rsh(n, 1)) > 0 {
+			s.Sub(n, s)
+		}
+	}
+	return helpers.EncodeSignatureToASN1(r.Bytes(), s.Bytes())
 }
 
 func (p *PrivateKey) PublicKeyIsCompatible(remote crypto.PublicKey) bool {

--- a/crypto/p521/public.go
+++ b/crypto/p521/public.go
@@ -137,6 +137,18 @@ func (p *PublicKey) VerifyBytes(message, signature []byte, opts ...crypto.Signin
 		return false
 	}
 
+	params := crypto.CollectSigningOptions(opts)
+
+	// The raw r||s form lets us check low-S directly, without decoding.
+	if params.EcdsaLowS() {
+		s := new(big.Int).SetBytes(signature[SignatureBytesSize/2:])
+		// new(big.Int).Rsh(N, 1) is N>>1, which is N/2,
+		// so this is "if s > N/2", i.e. reject high-S signatures
+		if s.Cmp(new(big.Int).Rsh(p.k.Curve.Params().N, 1)) > 0 {
+			return false
+		}
+	}
+
 	// For some reason, the go crypto library in ecdsa.Verify() encodes the signature as ASN.1 to then decode it.
 	// This means it's actually more efficient to encode the signature as ASN.1 here.
 	sigAsn1, err := helpers.EncodeSignatureToASN1(signature[:SignatureBytesSize/2], signature[SignatureBytesSize/2:])
@@ -144,13 +156,29 @@ func (p *PublicKey) VerifyBytes(message, signature []byte, opts ...crypto.Signin
 		return false
 	}
 
-	return p.VerifyASN1(message, sigAsn1, opts...)
+	return p.verify(params, message, sigAsn1)
 }
 
 // The default signing hash is SHA-512.
 func (p *PublicKey) VerifyASN1(message, signature []byte, opts ...crypto.SigningOption) bool {
 	params := crypto.CollectSigningOptions(opts)
 
+	if params.EcdsaLowS() {
+		_, s, err := helpers.DecodeSignatureFromASN1(signature)
+		// new(big.Int).Rsh(N, 1) is N>>1, which is N/2,
+		// so this is "if s > N/2", i.e. reject high-S signatures
+		if err != nil || s.Cmp(new(big.Int).Rsh(p.k.Curve.Params().N, 1)) > 0 {
+			return false
+		}
+	}
+
+	return p.verify(params, message, signature)
+}
+
+// verify checks the varsig constraints and the ASN.1 signature. Low-S enforcement,
+// if requested, is done by the exported VerifyBytes/VerifyASN1 from their respective
+// signature forms, so it is not repeated here.
+func (p *PublicKey) verify(params crypto.SigningOpts, message, sigAsn1 []byte) bool {
 	if !params.VarsigMatch(varsig.AlgorithmECDSA, uint64(varsig.CurveP521), 0) {
 		return false
 	}
@@ -159,7 +187,7 @@ func (p *PublicKey) VerifyASN1(message, signature []byte, opts ...crypto.Signing
 	hasher.Write(message)
 	hash := hasher.Sum(nil)
 
-	return ecdsa.VerifyASN1(p.k, hash[:], signature)
+	return ecdsa.VerifyASN1(p.k, hash, sigAsn1)
 }
 
 // Unwrap returns the underlying crypto/ecdsa public key.

--- a/crypto/secp256k1/key_test.go
+++ b/crypto/secp256k1/key_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"math/big"
 	"testing"
 
 	"github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
@@ -35,6 +36,11 @@ var harness = testsuite.TestHarness[*PublicKey, *PrivateKey]{
 
 func TestSuite(t *testing.T) {
 	testsuite.TestSuite(t, harness)
+}
+
+func TestEcdsaLowS(t *testing.T) {
+	n, _ := new(big.Int).SetString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141", 16)
+	testsuite.TestEcdsaLowSSuite(t, harness, n)
 }
 
 func BenchmarkSuite(b *testing.B) {

--- a/crypto/secp256k1/public.go
+++ b/crypto/secp256k1/public.go
@@ -238,6 +238,9 @@ func (p *PublicKey) VerifyBytes(message, signature []byte, opts ...crypto.Signin
 	if s.SetByteSlice(signature[32:]) {
 		return false // s >= curve order n
 	}
+	if params.EcdsaLowS() && s.IsOverHalfOrder() {
+		return false
+	}
 
 	return ecdsa.NewSignature(&r, &s).Verify(hash, p.k)
 }
@@ -257,6 +260,13 @@ func (p *PublicKey) VerifyASN1(message, signature []byte, opts ...crypto.Signing
 	sig, err := ecdsa.ParseDERSignature(signature)
 	if err != nil {
 		return false
+	}
+
+	if params.EcdsaLowS() {
+		s := sig.S()
+		if s.IsOverHalfOrder() {
+			return false
+		}
 	}
 
 	return sig.Verify(hash, p.k)

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/MetaMask/go-did-it
 
-go 1.24.4
-
-toolchain go1.24.5
+go 1.25.0
 
 require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0
@@ -11,7 +9,7 @@ require (
 	github.com/multiformats/go-varint v0.0.7
 	github.com/stretchr/testify v1.10.0
 	github.com/ucan-wg/go-varsig v1.0.0
-	golang.org/x/crypto v0.45.0
+	golang.org/x/crypto v0.50.0
 )
 
 require (
@@ -19,6 +17,6 @@ require (
 	github.com/multiformats/go-base32 v0.0.3 // indirect
 	github.com/multiformats/go-base36 v0.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/sys v0.38.0 // indirect
+	golang.org/x/sys v0.43.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -20,10 +20,10 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/ucan-wg/go-varsig v1.0.0 h1:Hrc437Zg+B5Eoajg+qZQZI3Q3ocPyjlnp3/Bz9ZnlWw=
 github.com/ucan-wg/go-varsig v1.0.0/go.mod h1:Sakln6IPooDPH+ClQ0VvR09TuwUhHcfLqcPiPkMZGh0=
-golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=
-golang.org/x/crypto v0.45.0/go.mod h1:XTGrrkGJve7CYK7J8PEww4aY7gM3qMCElcJQ8n8JdX4=
-golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
-golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
+golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
+golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
+golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes ECDSA signature acceptance and production when callers opt in; default verify behavior is unchanged, but misusing the new option could break interoperability with peers that emit high-S.
> 
> **Overview**
> Adds **`WithEcdsaLowSSig`** so callers can request canonical ECDSA signatures with **s ≤ N/2** and matching verification that **rejects high-S** malleable variants.
> 
> **P-256, P-384, and P-521** sign paths normalize **s** when the option is set; **bytes** and **ASN.1** verify paths enforce low-S only with the option, while verification **without** the option still accepts high-S. **secp256k1** gains the same optional verify checks (signing already tends toward low-S). A shared **`TestEcdsaLowSSuite`** covers bytes and DER cases across curves, plus **`DecodeSignatureFromASN1`** for DER **S** checks.
> 
> CI and module metadata move to **Go 1.25.x / 1.26.x** and bump **`golang.org/x/crypto`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dffa2087f98c467a654e63f0dc229b25ad1532d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->