### PR TITLE
P256,P384,P512: reject incorrect ECDSA curve when reading keys

### DIFF
--- a/crypto/p256/key_test.go
+++ b/crypto/p256/key_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/MetaMask/go-did-it/crypto"
 	"github.com/MetaMask/go-did-it/crypto/_testsuite"
+	"github.com/MetaMask/go-did-it/crypto/p384"
+	"github.com/MetaMask/go-did-it/crypto/p521"
 )
 
 var harness = testsuite.TestHarness[*PublicKey, *PrivateKey]{
@@ -57,4 +59,47 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE+UhEHZqcaKn+qhNtMmW843ZTRkX/
 	require.NoError(t, err)
 
 	require.True(t, pub.VerifyASN1([]byte("message"), sig))
+}
+
+func TestRejectForeignCurveX509AndPKCS8(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		pubDER  func() []byte
+		privDER func() []byte
+	}{
+		{
+			name: "p384",
+			pubDER: func() []byte {
+				pub, _, err := p384.GenerateKeyPair()
+				require.NoError(t, err)
+				return pub.ToX509DER()
+			},
+			privDER: func() []byte {
+				_, priv, err := p384.GenerateKeyPair()
+				require.NoError(t, err)
+				return priv.ToPKCS8DER()
+			},
+		},
+		{
+			name: "p521",
+			pubDER: func() []byte {
+				pub, _, err := p521.GenerateKeyPair()
+				require.NoError(t, err)
+				return pub.ToX509DER()
+			},
+			privDER: func() []byte {
+				_, priv, err := p521.GenerateKeyPair()
+				require.NoError(t, err)
+				return priv.ToPKCS8DER()
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := PublicKeyFromX509DER(tc.pubDER())
+			require.Error(t, err)
+
+			_, err = PrivateKeyFromPKCS8DER(tc.privDER())
+			require.Error(t, err)
+		})
+	}
 }

--- a/crypto/p256/private.go
+++ b/crypto/p256/private.go
@@ -56,6 +56,9 @@ func PrivateKeyFromPKCS8DER(bytes []byte) (*PrivateKey, error) {
 	if !ok {
 		return nil, fmt.Errorf("invalid private key type")
 	}
+	if ecdsaPriv.Curve != elliptic.P256() {
+		return nil, fmt.Errorf("invalid P-256 private key curve")
+	}
 	return &PrivateKey{k: ecdsaPriv}, nil
 }
 

--- a/crypto/p256/public.go
+++ b/crypto/p256/public.go
@@ -73,6 +73,9 @@ func PublicKeyFromX509DER(bytes []byte) (*PublicKey, error) {
 	if !ok {
 		return nil, fmt.Errorf("invalid public key")
 	}
+	if ecdsaPub.Curve != elliptic.P256() {
+		return nil, fmt.Errorf("invalid P-256 public key curve")
+	}
 	return &PublicKey{k: ecdsaPub}, nil
 }
 

--- a/crypto/p384/key_test.go
+++ b/crypto/p384/key_test.go
@@ -3,8 +3,12 @@ package p384
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/MetaMask/go-did-it/crypto"
 	"github.com/MetaMask/go-did-it/crypto/_testsuite"
+	"github.com/MetaMask/go-did-it/crypto/p256"
+	"github.com/MetaMask/go-did-it/crypto/p521"
 )
 
 var harness = testsuite.TestHarness[*PublicKey, *PrivateKey]{
@@ -32,4 +36,47 @@ func TestSuite(t *testing.T) {
 
 func BenchmarkSuite(b *testing.B) {
 	testsuite.BenchSuite(b, harness)
+}
+
+func TestRejectForeignCurveX509AndPKCS8(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		pubDER  func() []byte
+		privDER func() []byte
+	}{
+		{
+			name: "p256",
+			pubDER: func() []byte {
+				pub, _, err := p256.GenerateKeyPair()
+				require.NoError(t, err)
+				return pub.ToX509DER()
+			},
+			privDER: func() []byte {
+				_, priv, err := p256.GenerateKeyPair()
+				require.NoError(t, err)
+				return priv.ToPKCS8DER()
+			},
+		},
+		{
+			name: "p521",
+			pubDER: func() []byte {
+				pub, _, err := p521.GenerateKeyPair()
+				require.NoError(t, err)
+				return pub.ToX509DER()
+			},
+			privDER: func() []byte {
+				_, priv, err := p521.GenerateKeyPair()
+				require.NoError(t, err)
+				return priv.ToPKCS8DER()
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := PublicKeyFromX509DER(tc.pubDER())
+			require.Error(t, err)
+
+			_, err = PrivateKeyFromPKCS8DER(tc.privDER())
+			require.Error(t, err)
+		})
+	}
 }

--- a/crypto/p384/private.go
+++ b/crypto/p384/private.go
@@ -56,6 +56,9 @@ func PrivateKeyFromPKCS8DER(bytes []byte) (*PrivateKey, error) {
 	if !ok {
 		return nil, fmt.Errorf("invalid private key type")
 	}
+	if ecdsaPriv.Curve != elliptic.P384() {
+		return nil, fmt.Errorf("invalid P-384 private key curve")
+	}
 	return &PrivateKey{k: ecdsaPriv}, nil
 }
 

--- a/crypto/p384/public.go
+++ b/crypto/p384/public.go
@@ -73,6 +73,9 @@ func PublicKeyFromX509DER(bytes []byte) (*PublicKey, error) {
 	if !ok {
 		return nil, fmt.Errorf("invalid public key")
 	}
+	if ecdsaPub.Curve != elliptic.P384() {
+		return nil, fmt.Errorf("invalid P-384 public key curve")
+	}
 	return &PublicKey{k: ecdsaPub}, nil
 }
 

--- a/crypto/p521/key_test.go
+++ b/crypto/p521/key_test.go
@@ -3,8 +3,12 @@ package p521
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/MetaMask/go-did-it/crypto"
 	"github.com/MetaMask/go-did-it/crypto/_testsuite"
+	"github.com/MetaMask/go-did-it/crypto/p256"
+	"github.com/MetaMask/go-did-it/crypto/p384"
 )
 
 var harness = testsuite.TestHarness[*PublicKey, *PrivateKey]{
@@ -32,4 +36,47 @@ func TestSuite(t *testing.T) {
 
 func BenchmarkSuite(b *testing.B) {
 	testsuite.BenchSuite(b, harness)
+}
+
+func TestRejectForeignCurveX509AndPKCS8(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		pubDER  func() []byte
+		privDER func() []byte
+	}{
+		{
+			name: "p256",
+			pubDER: func() []byte {
+				pub, _, err := p256.GenerateKeyPair()
+				require.NoError(t, err)
+				return pub.ToX509DER()
+			},
+			privDER: func() []byte {
+				_, priv, err := p256.GenerateKeyPair()
+				require.NoError(t, err)
+				return priv.ToPKCS8DER()
+			},
+		},
+		{
+			name: "p384",
+			pubDER: func() []byte {
+				pub, _, err := p384.GenerateKeyPair()
+				require.NoError(t, err)
+				return pub.ToX509DER()
+			},
+			privDER: func() []byte {
+				_, priv, err := p384.GenerateKeyPair()
+				require.NoError(t, err)
+				return priv.ToPKCS8DER()
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := PublicKeyFromX509DER(tc.pubDER())
+			require.Error(t, err)
+
+			_, err = PrivateKeyFromPKCS8DER(tc.privDER())
+			require.Error(t, err)
+		})
+	}
 }

--- a/crypto/p521/private.go
+++ b/crypto/p521/private.go
@@ -56,6 +56,9 @@ func PrivateKeyFromPKCS8DER(bytes []byte) (*PrivateKey, error) {
 	if !ok {
 		return nil, fmt.Errorf("invalid private key type")
 	}
+	if ecdsaPriv.Curve != elliptic.P521() {
+		return nil, fmt.Errorf("invalid P-521 private key curve")
+	}
 	return &PrivateKey{k: ecdsaPriv}, nil
 }
 

--- a/crypto/p521/public.go
+++ b/crypto/p521/public.go
@@ -73,6 +73,9 @@ func PublicKeyFromX509DER(bytes []byte) (*PublicKey, error) {
 	if !ok {
 		return nil, fmt.Errorf("invalid public key")
 	}
+	if ecdsaPub.Curve != elliptic.P521() {
+		return nil, fmt.Errorf("invalid P-521 public key curve")
+	}
 	return &PublicKey{k: ecdsaPub}, nil
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Tightens cryptographic key parsing in security-sensitive code; valid keys on the correct curve are unchanged, but previously accepted wrong-curve imports will now error.
> 
> **Overview**
> **P-256, P-384, and P-521** key loaders now **reject keys on the wrong curve** when importing **X.509 DER public keys** and **PKCS#8 DER private keys**. Each package checks `ecdsaPub.Curve` / `ecdsaPriv.Curve` against its expected `elliptic` curve and returns a clear error instead of accepting another NIST curve’s material.
> 
> **Tests** add `TestRejectForeignCurveX509AndPKCS8` in each package, generating keys from sibling curves and asserting `PublicKeyFromX509DER` and `PrivateKeyFromPKCS8DER` fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86d95b970b87a832dabd4d580d8c46280650a260. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->