### PR TITLE
p256,P384,P521: reject keys as bytes if out of curve range

### DIFF
--- a/crypto/jwk/private_test.go
+++ b/crypto/jwk/private_test.go
@@ -1,10 +1,16 @@
 package jwk
 
 import (
+	"crypto/elliptic"
+	"encoding/base64"
 	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/MetaMask/go-did-it/crypto/p256"
+	"github.com/MetaMask/go-did-it/crypto/p384"
+	"github.com/MetaMask/go-did-it/crypto/p521"
 )
 
 // Origin: https://github.com/w3c-ccg/did-key-spec/tree/main/test-vectors
@@ -131,6 +137,60 @@ func TestPrivateJwkRoundtrip(t *testing.T) {
 			bytes, err := json.Marshal(priv)
 			require.NoError(t, err)
 			require.JSONEq(t, tc.in, string(bytes))
+		})
+	}
+}
+
+func TestPrivateJwkRejectInvalidNistScalars(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		crv  string
+		d    []byte
+	}{
+		{
+			name: "p256 zero",
+			crv:  "P-256",
+			d:    make([]byte, p256.PrivateKeyBytesSize),
+		},
+		{
+			name: "p256 order",
+			crv:  "P-256",
+			d:    elliptic.P256().Params().N.FillBytes(make([]byte, p256.PrivateKeyBytesSize)),
+		},
+		{
+			name: "p384 zero",
+			crv:  "P-384",
+			d:    make([]byte, p384.PrivateKeyBytesSize),
+		},
+		{
+			name: "p384 order",
+			crv:  "P-384",
+			d:    elliptic.P384().Params().N.FillBytes(make([]byte, p384.PrivateKeyBytesSize)),
+		},
+		{
+			name: "p521 zero",
+			crv:  "P-521",
+			d:    make([]byte, p521.PrivateKeyBytesSize),
+		},
+		{
+			name: "p521 order",
+			crv:  "P-521",
+			d:    elliptic.P521().Params().N.FillBytes(make([]byte, p521.PrivateKeyBytesSize)),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			in := map[string]string{
+				"kty": "EC",
+				"crv": tc.crv,
+				"d":   base64.RawURLEncoding.EncodeToString(tc.d),
+			}
+
+			body, err := json.Marshal(in)
+			require.NoError(t, err)
+
+			var priv PrivateJwk
+			err = json.Unmarshal(body, &priv)
+			require.Error(t, err)
 		})
 	}
 }

--- a/crypto/p256/key_test.go
+++ b/crypto/p256/key_test.go
@@ -1,6 +1,7 @@
 package p256
 
 import (
+	"crypto/elliptic"
 	"encoding/base64"
 	"testing"
 
@@ -102,4 +103,14 @@ func TestRejectForeignCurveX509AndPKCS8(t *testing.T) {
 			require.Error(t, err)
 		})
 	}
+}
+
+func TestRejectInvalidPrivateScalars(t *testing.T) {
+	// Zero is outside the valid scalar range [1, N-1].
+	_, err := PrivateKeyFromBytes(make([]byte, PrivateKeyBytesSize))
+	require.Error(t, err)
+
+	// N is out of range; valid scalars are [1, N-1].
+	_, err = PrivateKeyFromBytes(elliptic.P256().Params().N.FillBytes(make([]byte, PrivateKeyBytesSize)))
+	require.Error(t, err)
 }

--- a/crypto/p256/private.go
+++ b/crypto/p256/private.go
@@ -27,15 +27,19 @@ type PrivateKey struct {
 
 // PrivateKeyFromBytes converts a serialized public key to a PrivateKey.
 // This compact serialization format is the raw key material, without metadata or structure.
-// It errors if the slice is not the right size.
+// It errors out if the slice is not the right size or the curve point is invalid.
 func PrivateKeyFromBytes(b []byte) (*PrivateKey, error) {
 	if len(b) != PrivateKeyBytesSize {
 		return nil, fmt.Errorf("invalid P-256 private key size")
 	}
+	d := new(big.Int).SetBytes(b)
+	if d.Sign() <= 0 || d.Cmp(elliptic.P256().Params().N) >= 0 {
+		return nil, fmt.Errorf("invalid P-256 private key scalar")
+	}
 
 	res := &PrivateKey{
 		k: &ecdsa.PrivateKey{
-			D:         new(big.Int).SetBytes(b),
+			D:         d,
 			PublicKey: ecdsa.PublicKey{Curve: elliptic.P256()},
 		},
 	}

--- a/crypto/p384/key_test.go
+++ b/crypto/p384/key_test.go
@@ -1,6 +1,7 @@
 package p384
 
 import (
+	"crypto/elliptic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -79,4 +80,14 @@ func TestRejectForeignCurveX509AndPKCS8(t *testing.T) {
 			require.Error(t, err)
 		})
 	}
+}
+
+func TestRejectInvalidPrivateScalars(t *testing.T) {
+	// Zero is outside the valid scalar range [1, N-1].
+	_, err := PrivateKeyFromBytes(make([]byte, PrivateKeyBytesSize))
+	require.Error(t, err)
+
+	// N is out of range; valid scalars are [1, N-1].
+	_, err = PrivateKeyFromBytes(elliptic.P384().Params().N.FillBytes(make([]byte, PrivateKeyBytesSize)))
+	require.Error(t, err)
 }

--- a/crypto/p384/private.go
+++ b/crypto/p384/private.go
@@ -27,15 +27,19 @@ type PrivateKey struct {
 
 // PrivateKeyFromBytes converts a serialized public key to a PrivateKey.
 // This compact serialization format is the raw key material, without metadata or structure.
-// It errors if the slice is not the right size.
+// It errors out if the slice is not the right size or the curve point is invalid.
 func PrivateKeyFromBytes(b []byte) (*PrivateKey, error) {
 	if len(b) != PrivateKeyBytesSize {
 		return nil, fmt.Errorf("invalid P-384 private key size")
 	}
+	d := new(big.Int).SetBytes(b)
+	if d.Sign() <= 0 || d.Cmp(elliptic.P384().Params().N) >= 0 {
+		return nil, fmt.Errorf("invalid P-384 private key scalar")
+	}
 
 	res := &PrivateKey{
 		k: &ecdsa.PrivateKey{
-			D:         new(big.Int).SetBytes(b),
+			D:         d,
 			PublicKey: ecdsa.PublicKey{Curve: elliptic.P384()},
 		},
 	}

--- a/crypto/p521/key_test.go
+++ b/crypto/p521/key_test.go
@@ -1,6 +1,7 @@
 package p521
 
 import (
+	"crypto/elliptic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -79,4 +80,14 @@ func TestRejectForeignCurveX509AndPKCS8(t *testing.T) {
 			require.Error(t, err)
 		})
 	}
+}
+
+func TestRejectInvalidPrivateScalars(t *testing.T) {
+	// Zero is outside the valid scalar range [1, N-1].
+	_, err := PrivateKeyFromBytes(make([]byte, PrivateKeyBytesSize))
+	require.Error(t, err)
+
+	// N is out of range; valid scalars are [1, N-1].
+	_, err = PrivateKeyFromBytes(elliptic.P521().Params().N.FillBytes(make([]byte, PrivateKeyBytesSize)))
+	require.Error(t, err)
 }

--- a/crypto/p521/private.go
+++ b/crypto/p521/private.go
@@ -27,15 +27,19 @@ type PrivateKey struct {
 
 // PrivateKeyFromBytes converts a serialized public key to a PrivateKey.
 // This compact serialization format is the raw key material, without metadata or structure.
-// It errors if the slice is not the right size.
+// It errors out if the slice is not the right size or the curve point is invalid.
 func PrivateKeyFromBytes(b []byte) (*PrivateKey, error) {
 	if len(b) != PrivateKeyBytesSize {
 		return nil, fmt.Errorf("invalid P-521 private key size")
 	}
+	d := new(big.Int).SetBytes(b)
+	if d.Sign() <= 0 || d.Cmp(elliptic.P521().Params().N) >= 0 {
+		return nil, fmt.Errorf("invalid P-521 private key scalar")
+	}
 
 	res := &PrivateKey{
 		k: &ecdsa.PrivateKey{
-			D:         new(big.Int).SetBytes(b),
+			D:         d,
 			PublicKey: ecdsa.PublicKey{Curve: elliptic.P521()},
 		},
 	}

--- a/crypto/rsa/key_test.go
+++ b/crypto/rsa/key_test.go
@@ -1,6 +1,7 @@
 package rsa
 
 import (
+	"crypto/x509"
 	"encoding/base64"
 	"testing"
 
@@ -164,4 +165,102 @@ MCB+kOgWk51uJwuiuHlffGMBPxku/t+skxI7Bw==`
 	require.NoError(t, err)
 
 	require.True(t, pub.VerifyASN1([]byte("message"), sig))
+}
+
+func TestPublicKeyPKCS1RoundTrip(t *testing.T) {
+	pub, _, err := GenerateKeyPair(2048)
+	require.NoError(t, err)
+
+	der := x509.MarshalPKCS1PublicKey(pub.Unwrap())
+	rt, err := PublicKeyFromPKCS1DER(der)
+	require.NoError(t, err)
+	require.True(t, pub.Equal(rt))
+}
+
+func TestPublicKeyFromNERoundTrip(t *testing.T) {
+	pub, _, err := GenerateKeyPair(2048)
+	require.NoError(t, err)
+
+	rt, err := PublicKeyFromNE(pub.NBytes(), pub.EBytes())
+	require.NoError(t, err)
+	require.True(t, pub.Equal(rt))
+}
+
+func TestPrivateKeyFromNEDPQRoundTrip(t *testing.T) {
+	pub, priv, err := GenerateKeyPair(2048)
+	require.NoError(t, err)
+
+	rt, err := PrivateKeyFromNEDPQ(pub.NBytes(), pub.EBytes(), priv.DBytes(), priv.PBytes(), priv.QBytes())
+	require.NoError(t, err)
+	require.True(t, priv.Equal(rt))
+	require.True(t, pub.Equal(rt.Public()))
+}
+
+func TestRejectWeirdPublicKeyInputs(t *testing.T) {
+	// Reuse a known-good 2048-bit modulus so each case changes only the input under test.
+	validModulus, err := base64.RawURLEncoding.DecodeString("sbX82NTV6IylxCh7MfV4hlyvaniCajuP97GyOqSvTmoEdBOflFvZ06kR_9D6ctt45Fk6hskfnag2GG69NALVH2o4RCR6tQiLRpKcMRtDYE_thEmfBvDzm_VVkOIYfxu-Ipuo9J_S5XDNDjczx2v-3oDh5-CIHkU46hvFeCvpUS-L8TJSbgX0kjVk_m4eIb9wh63rtmD6Uz_KBtCo5mmR4TEtcLZKYdqMp3wCjN-TlgHiz_4oVXWbHUefCEe8rFnX1iQnpDHU49_SaXQoud1jCaexFn25n-Aa8f8bc5Vm-5SeRwidHa6ErvEhTvf1dz6GoNPp2iRvm-wJ1gxwWJEYPQ")
+	require.NoError(t, err)
+
+	evenModulus := append([]byte{}, validModulus...)
+	evenModulus[len(evenModulus)-1] &^= 1
+
+	// Build a 8193-bit odd modulus to exceed the package's 8192-bit upper bound.
+	tooLargeModulus := make([]byte, 1025)
+	tooLargeModulus[0] = 0x80
+	tooLargeModulus[len(tooLargeModulus)-1] = 0x01
+
+	// This is 2^63, which does not fit in a signed int64 and must be rejected.
+	exponentTooLarge := []byte{0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+
+	for _, tc := range []struct {
+		name string
+		n    []byte
+		e    []byte
+	}{
+		{
+			name: "empty modulus",
+			n:    nil,
+			e:    []byte{0x03},
+		},
+		{
+			name: "too small modulus",
+			n:    validModulus[:len(validModulus)-1],
+			e:    []byte{0x03},
+		},
+		{
+			name: "too large modulus",
+			n:    tooLargeModulus,
+			e:    []byte{0x03},
+		},
+		{
+			name: "even modulus",
+			n:    evenModulus,
+			e:    []byte{0x03},
+		},
+		{
+			name: "empty exponent",
+			n:    validModulus,
+			e:    nil,
+		},
+		{
+			name: "exponent one",
+			n:    validModulus,
+			e:    []byte{0x01},
+		},
+		{
+			name: "even exponent",
+			n:    validModulus,
+			e:    []byte{0x02},
+		},
+		{
+			name: "exponent too large",
+			n:    validModulus,
+			e:    exponentTooLarge,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := PublicKeyFromNE(tc.n, tc.e)
+			require.Error(t, err)
+		})
+	}
 }

--- a/crypto/rsa/public.go
+++ b/crypto/rsa/public.go
@@ -53,6 +53,9 @@ func PublicKeyFromNE(n, e []byte) (*PublicKey, error) {
 	if eBInt.Sign() <= 0 {
 		return nil, fmt.Errorf("exponent must be positive")
 	}
+	if eBInt.Cmp(big.NewInt(2)) < 0 {
+		return nil, fmt.Errorf("exponent too small")
+	}
 	if eBInt.Bit(0) == 0 {
 		return nil, fmt.Errorf("exponent must be odd")
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Stricter crypto key parsing can reject previously accepted malformed keys (especially EC JWK `d` and RSA `e=1`), which is desirable for security but may break callers relying on lax behavior.
> 
> **Overview**
> Tightens **key import validation** for NIST EC curves and RSA public material.
> 
> **P-256, P-384, and P-521:** `PrivateKeyFromBytes` now rejects scalars outside **[1, N−1]** (zero and curve order **N**), with matching unit tests and JWK tests that expect unmarshaling invalid `d` values to fail.
> 
> **RSA:** `PublicKeyFromNE` rejects exponents **&lt; 2** (e.g. **e = 1**). New tests cover PKCS1/NE/NEDPQ round-trips and rejection of bad modulus/exponent inputs (empty, wrong size, even modulus, even exponent, exponent too large for int64).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d239bbd509c687c474f5437e3bb6dd1e28b7611. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->