### PR TITLE
rsa: enforce key size limits on all constructors (priv+pub)

### DIFF
--- a/crypto/rsa/key_test.go
+++ b/crypto/rsa/key_test.go
@@ -1,14 +1,19 @@
 package rsa
 
 import (
+	"crypto/rand"
+	stdrsa "crypto/rsa"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/pem"
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/MetaMask/go-did-it/crypto"
 	"github.com/MetaMask/go-did-it/crypto/_testsuite"
+	helpers "github.com/MetaMask/go-did-it/crypto/internal"
 )
 
 var harness2048 = testsuite.TestHarness[*PublicKey, *PrivateKey]{
@@ -175,6 +180,105 @@ func TestPublicKeyPKCS1RoundTrip(t *testing.T) {
 	rt, err := PublicKeyFromPKCS1DER(der)
 	require.NoError(t, err)
 	require.True(t, pub.Equal(rt))
+}
+
+func TestRejectBelowPolicyRSAImports(t *testing.T) {
+	weak, err := stdrsa.GenerateKey(rand.Reader, 1024)
+	require.NoError(t, err)
+
+	pkixDER, err := x509.MarshalPKIXPublicKey(&weak.PublicKey)
+	require.NoError(t, err)
+	pkixPEM := string(pem.EncodeToMemory(&pem.Block{
+		Type:  pemPubBlockType,
+		Bytes: pkixDER,
+	}))
+	pkcs1DER := x509.MarshalPKCS1PublicKey(&weak.PublicKey)
+	publicKeyMultibase := helpers.PublicKeyMultibaseEncode(MultibaseCode, pkixDER)
+	pkcs8DER, err := x509.MarshalPKCS8PrivateKey(weak)
+	require.NoError(t, err)
+	pkcs8PEM := string(pem.EncodeToMemory(&pem.Block{
+		Type:  pemPrivBlockType,
+		Bytes: pkcs8DER,
+	}))
+
+	n := weak.N.Bytes()
+	e := big.NewInt(int64(weak.E)).Bytes()
+	d := weak.D.Bytes()
+	p := weak.Primes[0].Bytes()
+	q := weak.Primes[1].Bytes()
+
+	for _, tc := range []struct {
+		name      string
+		importKey func() error
+	}{
+		{
+			name: "GenerateKeyPair",
+			importKey: func() error {
+				_, _, err := GenerateKeyPair(1024)
+				return err
+			},
+		},
+		{
+			name: "PublicKeyFromNE",
+			importKey: func() error {
+				_, err := PublicKeyFromNE(n, e)
+				return err
+			},
+		},
+		{
+			name: "PublicKeyFromPublicKeyMultibase",
+			importKey: func() error {
+				_, err := PublicKeyFromPublicKeyMultibase(publicKeyMultibase)
+				return err
+			},
+		},
+		{
+			name: "PublicKeyFromX509DER",
+			importKey: func() error {
+				_, err := PublicKeyFromX509DER(pkixDER)
+				return err
+			},
+		},
+		{
+			name: "PublicKeyFromPKCS1DER",
+			importKey: func() error {
+				_, err := PublicKeyFromPKCS1DER(pkcs1DER)
+				return err
+			},
+		},
+		{
+			name: "PublicKeyFromX509PEM",
+			importKey: func() error {
+				_, err := PublicKeyFromX509PEM(pkixPEM)
+				return err
+			},
+		},
+		{
+			name: "PrivateKeyFromNEDPQ",
+			importKey: func() error {
+				_, err := PrivateKeyFromNEDPQ(n, e, d, p, q)
+				return err
+			},
+		},
+		{
+			name: "PrivateKeyFromPKCS8DER",
+			importKey: func() error {
+				_, err := PrivateKeyFromPKCS8DER(pkcs8DER)
+				return err
+			},
+		},
+		{
+			name: "PrivateKeyFromPKCS8PEM",
+			importKey: func() error {
+				_, err := PrivateKeyFromPKCS8PEM(pkcs8PEM)
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Error(t, tc.importKey())
+		})
+	}
 }
 
 func TestPublicKeyFromNERoundTrip(t *testing.T) {

--- a/crypto/rsa/private.go
+++ b/crypto/rsa/private.go
@@ -56,6 +56,13 @@ func PrivateKeyFromPKCS8DER(bytes []byte) (*PrivateKey, error) {
 	if !ok {
 		return nil, fmt.Errorf("invalid private key type")
 	}
+	if err := validatePublicKey(&rsaPriv.PublicKey); err != nil {
+		return nil, err
+	}
+	if err := rsaPriv.Validate(); err != nil {
+		return nil, err
+	}
+	rsaPriv.Precompute()
 	return &PrivateKey{k: rsaPriv}, nil
 }
 

--- a/crypto/rsa/public.go
+++ b/crypto/rsa/public.go
@@ -26,40 +26,23 @@ func PublicKeyFromPKCS1DER(bytes []byte) (*PublicKey, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := validatePublicKey(pub); err != nil {
+		return nil, err
+	}
 	return &PublicKey{k: pub}, nil
 }
 
 func PublicKeyFromNE(n, e []byte) (*PublicKey, error) {
 	nBInt := new(big.Int).SetBytes(n)
-	// some basic checks
-	if nBInt.Sign() <= 0 {
-		return nil, fmt.Errorf("invalid modulus")
-	}
-	if nBInt.BitLen() < MinRsaKeyBits {
-		return nil, fmt.Errorf("key length too small")
-	}
-	if nBInt.BitLen() > MaxRsaKeyBits {
-		return nil, fmt.Errorf("key length too large")
-	}
-	if nBInt.Bit(0) == 0 {
-		return nil, fmt.Errorf("modulus must be odd")
-	}
-
 	eBInt := new(big.Int).SetBytes(e)
-	// some basic checks
 	if !eBInt.IsInt64() {
 		return nil, fmt.Errorf("invalid exponent")
 	}
-	if eBInt.Sign() <= 0 {
-		return nil, fmt.Errorf("exponent must be positive")
+	pub := &rsa.PublicKey{N: nBInt, E: int(eBInt.Int64())}
+	if err := validatePublicKey(pub); err != nil {
+		return nil, err
 	}
-	if eBInt.Cmp(big.NewInt(2)) < 0 {
-		return nil, fmt.Errorf("exponent too small")
-	}
-	if eBInt.Bit(0) == 0 {
-		return nil, fmt.Errorf("exponent must be odd")
-	}
-	return &PublicKey{k: &rsa.PublicKey{N: nBInt, E: int(eBInt.Int64())}}, nil
+	return &PublicKey{k: pub}, nil
 }
 
 // PublicKeyFromPublicKeyMultibase decodes the public key from its Multibase form
@@ -84,6 +67,9 @@ func PublicKeyFromX509DER(bytes []byte) (*PublicKey, error) {
 	if !ok {
 		return nil, fmt.Errorf("invalid public key")
 	}
+	if err := validatePublicKey(rsaPub); err != nil {
+		return nil, err
+	}
 	return &PublicKey{k: rsaPub}, nil
 }
 
@@ -97,6 +83,34 @@ func PublicKeyFromX509PEM(str string) (*PublicKey, error) {
 		return nil, fmt.Errorf("incorrect PEM block type")
 	}
 	return PublicKeyFromX509DER(block.Bytes)
+}
+
+func validatePublicKey(pub *rsa.PublicKey) error {
+	if pub == nil || pub.N == nil {
+		return fmt.Errorf("invalid public key")
+	}
+	if pub.N.Sign() <= 0 {
+		return fmt.Errorf("invalid modulus")
+	}
+	if pub.N.BitLen() < MinRsaKeyBits {
+		return fmt.Errorf("key length too small")
+	}
+	if pub.N.BitLen() > MaxRsaKeyBits {
+		return fmt.Errorf("key length too large")
+	}
+	if pub.N.Bit(0) == 0 {
+		return fmt.Errorf("modulus must be odd")
+	}
+	if pub.E <= 0 {
+		return fmt.Errorf("exponent must be positive")
+	}
+	if pub.E < 2 {
+		return fmt.Errorf("exponent too small")
+	}
+	if pub.E%2 == 0 {
+		return fmt.Errorf("exponent must be odd")
+	}
+	return nil
 }
 
 func (p *PublicKey) KeyLength() uint64 {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Tightens cryptographic key acceptance on all import paths; behavior change for callers that relied on sub-2048-bit or malformed keys, but it hardens security rather than widening attack surface.
> 
> **Overview**
> **Centralizes RSA public-key policy** in a new `validatePublicKey` helper (modulus bit length within `MinRsaKeyBits`/`MaxRsaKeyBits`, odd modulus, valid exponent) and **runs it on every public import path** that previously only parsed DER/PEM or NE bytes—PKCS#1, PKIX/X509, multibase (via X509), and `PublicKeyFromNE` (inline checks replaced by the shared validator).
> 
> **Private PKCS#8 imports** now reject weak keys by validating the embedded public half, then call `rsa.PrivateKey.Validate()` and `Precompute()` before wrapping the key.
> 
> Adds **`TestRejectBelowPolicyRSAImports`** to assert 1024-bit material fails across generation and all listed public/private constructors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24414ae9582efad0371c2a09ac8b6814f791d4f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->